### PR TITLE
Removed the direct SHC url from routing

### DIFF
--- a/Resources/parameters.json
+++ b/Resources/parameters.json
@@ -38,7 +38,6 @@
                 "backendPool": "oldBackend",
                 "backendHttp": "defaultHttpSettings",
                 "paths": [
-                    "/skills-health-check/*",
                     "/ResourcePackages/*",
                     "/your-account/*",
                     "/home/signout*",


### PR DESCRIPTION
Removed SHC direct routing to BAU backend pool and left the rule only for SkillsAssessment/SHC