### PR TITLE
NCSD-1363: hostname on backend http setting

### DIFF
--- a/Resources/ArmTemplates/app-gateway.json
+++ b/Resources/ArmTemplates/app-gateway.json
@@ -341,7 +341,6 @@
                         "authenticationCertificates": "[if(contains(parameters('backendHttpSettings')[copyIndex('backendHttpSettings')],'authCerts'), parameters('backendHttpSettings')[copyIndex('backendHttpSettings')].authCerts, variables('blankArray'))]",
                         "trustedRootCertificates": "[if(contains(parameters('backendHttpSettings')[copyIndex('backendHttpSettings')],'rootCerts'), parameters('backendHttpSettings')[copyIndex('backendHttpSettings')].rootCerts, variables('blankArray'))]",
                         "pickHostNameFromBackendAddress": "[if(contains(parameters('backendHttpSettings')[copyIndex('backendHttpSettings')],'hostnameFromBackendAddress'), parameters('backendHttpSettings')[copyIndex('backendHttpSettings')].hostnameFromBackendAddress, json('true'))]",
-                        "hostName":"[if(contains(parameters('backendHttpSettings')[copyIndex('backendHttpSettings')],'hostname'), parameters('backendHttpSettings')[copyIndex('backendHttpSettings')].hostname, json('null'))]",
                         "probe": "[if(parameters('useCustomProbe'), if(equals(parameters('backendHttpSettings')[copyIndex('backendHttpSettings')].protocol, 'Https'), variables('httpsProbeId'), variables('httpProbeId')), json('null'))]"
                     }
                 }


### PR DESCRIPTION
Setting hostname to null does not pass test. As this may not be required now removing until a solution can be found to optional setting.