### PR TITLE
Revert "Removed the direct SHC url from routing"

### DIFF
--- a/Resources/parameters.json
+++ b/Resources/parameters.json
@@ -44,6 +44,7 @@
                 "backendPool": "bauBackend",
                 "backendHttp": "bauHttpSettings",
                 "paths": [
+                    "/skills-health-check/*",
                     "/ResourcePackages/*",
                     "/your-account/*",
                     "/home/signout*",


### PR DESCRIPTION
Reverts SkillsFundingAgency/dfc-shared-appgateway#16

There are form post that goes to the old url and so it is required.