### PR TITLE
Remove path "your-account" from BAU

### DIFF
--- a/Resources/parameters.json
+++ b/Resources/parameters.json
@@ -108,7 +108,7 @@
                     "/account*",
                     "/startshclink*",
                     "/ResourcePackages/*",
-                    "/your-account*",
+                    "/bau/your-account*",
                     "/home/signout*",
                     "/home/signin*",
                     "/course-directory/*",


### PR DESCRIPTION
Remove path "your-account" from BAU backend pool
Added /bau/your-account path for backward compatibility during transition