### PR TITLE
NCSD-4498 Removed skills toolkit find a course path from Composite

### DIFF
--- a/Resources/parameters.json
+++ b/Resources/parameters.json
@@ -156,11 +156,7 @@
                     "/job-profiles",
                     "/job-profiles/*",
                     "/alerts",
-                    "/alerts/*",
-                    "/find-a-course/the-skills-toolkit",
-                    "/find-a-course/the-skills-toolkit/*",
-                    "/find-a-course/the-skills-toolkit-legal-disclaimer",
-                    "/find-a-course/the-skills-toolkit-legal-disclaimer/*"
+                    "/alerts/*"
                 ]
             },{
                 "name": "sflookback",


### PR DESCRIPTION
As per CHG0051117 removed Find a course skills toolkit from composite shell path route.

                    "/find-a-course/the-skills-toolkit",		
                    "/find-a-course/the-skills-toolkit/*",		
                    "/find-a-course/the-skills-toolkit-legal-disclaimer",		
                    "/find-a-course/the-skills-toolkit-legal-disclaimer/*"